### PR TITLE
Fix typo 'acceptible'

### DIFF
--- a/Module/Simulation/Trajectory/pykep/src/third_party/cspice/dcbrt.c
+++ b/Module/Simulation/Trajectory/pykep/src/third_party/cspice/dcbrt.c
@@ -83,7 +83,7 @@ doublereal dcbrt_(doublereal *x)
 /*      value of the input variable, and then the sign of the input */
 /*      is transferred to the output value. */
 
-/*      All values of the input variable X should be acceptible to the */
+/*      All values of the input variable X should be acceptable to the */
 /*      DCBRT. */
 
 /* $ Examples */


### PR DESCRIPTION
Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'acceptable', you typed 'acceptible'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

If you decide to close this pull request, pleace specify why before doing so.

With kind regards,
TheTypoMaster
